### PR TITLE
Wrap levels

### DIFF
--- a/Assets/_Scripts/SceneHandler.cs
+++ b/Assets/_Scripts/SceneHandler.cs
@@ -34,6 +34,9 @@ public class SceneHandler : SingletonMonoBehavior<SceneHandler>
     {
         if(nextLevelIndex >= levels.Count)
         {
+            // All levels have been completed, reset back to the first lavel to be able 
+            // to replay the game.
+            nextLevelIndex = 0;
             LoadMenuScene();
         }
         else


### PR DESCRIPTION
There was already a code path from the final scene redirecting to the main menu, 
now reset the next scene to show to the first scene as opposed to always keeping the last 
scene in that code path.