### PR TITLE
Fix scene transition animation

### DIFF
--- a/Assets/_Scenes/_Preload.unity
+++ b/Assets/_Scenes/_Preload.unity
@@ -168,7 +168,7 @@ MonoBehaviour:
   - Level 1
   - Level 2
   menuScene: MainMenu
-  animationType: 19
+  animationType: 35
   animationDuration: 1
   transitionCanvas: {fileID: 1003730455}
 --- !u!114 &681802681

--- a/Assets/_Scripts/SceneHandler.cs
+++ b/Assets/_Scripts/SceneHandler.cs
@@ -27,7 +27,7 @@ public class SceneHandler : SingletonMonoBehavior<SceneHandler>
 
     private void OnSceneLoad(Scene scene, LoadSceneMode _)
     {
-        transitionCanvas.DOLocalMoveX(initXPosition, animationDuration).SetEase(animationType);
+        // transitionCanvas.DOLocalMoveX(initXPosition, animationDuration).SetEase(animationType);
     }
 
     public void LoadNextScene()
@@ -38,7 +38,8 @@ public class SceneHandler : SingletonMonoBehavior<SceneHandler>
         }
         else
         {
-            transitionCanvas.DOLocalMoveX(initXPosition + transitionCanvas.rect.width, animationDuration).SetEase(animationType);
+            var distanceToCoverScreen = transitionCanvas.rect.width * 1.5f;
+            transitionCanvas.DOLocalMoveX(initXPosition + distanceToCoverScreen, animationDuration).SetEase(animationType);
             StartCoroutine(LoadSceneAfterTransition(levels[nextLevelIndex]));
             nextLevelIndex++;
         }
@@ -51,9 +52,21 @@ public class SceneHandler : SingletonMonoBehavior<SceneHandler>
         nextLevelIndex = 0;
     }
 
+    private IEnumerator ResetTransitionCanvas() 
+    {
+        yield return new WaitForSeconds(animationDuration);
+        var localPosition = transitionCanvas.localPosition;
+        transitionCanvas.localPosition = new Vector3(initXPosition, localPosition.y, localPosition.z);
+    }
+
     private IEnumerator LoadSceneAfterTransition(string scene)
     {
         yield return new WaitForSeconds(animationDuration);
         SceneManager.LoadScene(scene);
+
+        var distanceToCoverScreen = transitionCanvas.rect.width * 1.5f;
+        var distanceToLeaveScreen = distanceToCoverScreen * 2.0f;
+        transitionCanvas.DOLocalMoveX(initXPosition + distanceToLeaveScreen, animationDuration).SetEase(animationType);
+        StartCoroutine(ResetTransitionCanvas());
     }
 }


### PR DESCRIPTION
Scene transition animation now fully covers the screen so the player can no longer see the scene change.

Scene transition is done via a black canvas which moves to cover the screen in the _Preload scene,
this canvas was only moving to cover half the screen, meaning the player could still see the scene change.
Changed the canvas to move to cover the entire screen. 

Also the canvas now exits the other way.