### PR TITLE
Made the ball speedup on brick break

### DIFF
--- a/Assets/Prefabs/Ball.prefab
+++ b/Assets/Prefabs/Ball.prefab
@@ -98,6 +98,7 @@ MonoBehaviour:
   ballLaunchSpeed: 7
   minBallBounceBackSpeed: 6
   maxBallBounceBackSpeed: 10
+  ballSpeedUpSpeed: 1
   ballAnchor: {fileID: 0}
   rb: {fileID: 8959031048966596842}
 --- !u!1 &4625805382739171240

--- a/Assets/_Scripts/Logic/Ball.cs
+++ b/Assets/_Scripts/Logic/Ball.cs
@@ -6,6 +6,7 @@ public class Ball : MonoBehaviour
     [SerializeField] private float ballLaunchSpeed;
     [SerializeField] private float minBallBounceBackSpeed;
     [SerializeField] private float maxBallBounceBackSpeed;
+    [SerializeField] private float ballSpeedUpSpeed;
     [Header("References")]
     [SerializeField] private Transform ballAnchor;
     [SerializeField] private Rigidbody rb;
@@ -14,7 +15,7 @@ public class Ball : MonoBehaviour
 
     private void OnCollisionEnter(Collision other)
     {
-        if(other.gameObject.CompareTag("Paddle"))
+        if (other.gameObject.CompareTag("Paddle"))
         {
 
             // Camera shake on collision with paddle ( shorter/weaker shake)
@@ -28,6 +29,15 @@ public class Ball : MonoBehaviour
             rb.angularVelocity = Vector3.zero;
             rb.AddForce(directionToFire * returnSpeed, ForceMode.Impulse);
         }
+        else if (other.gameObject.CompareTag("Bricks"))
+        {
+            // Linear speed up function is not very interesting but 
+            // easier for the player to manage and to tune compared to 
+            // exponential.
+            minBallBounceBackSpeed += ballSpeedUpSpeed;
+            maxBallBounceBackSpeed += ballSpeedUpSpeed;
+        }
+
     }
 
     public void ResetBall()


### PR DESCRIPTION
As it was it was fairly difficult to lose the game which made the game not very exciting. 
Now the ball speeds up slightly with every broken brick making it somewhat more easy to lose. 

The form of difficulty also kind of automatically scales with the levels because they just happen to have more blocks 
the further you go.